### PR TITLE
Improve logging and update swan

### DIFF
--- a/src/packages/EmbedIO/EmbedIO.csproj
+++ b/src/packages/EmbedIO/EmbedIO.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unosquare.Swan.Lite" Version="3.0.0" />
+    <PackageReference Include="Unosquare.Swan.Lite" Version="3.*" />
   </ItemGroup>
   
 </Project>

--- a/src/packages/EmbedIO/ExceptionHandler.cs
+++ b/src/packages/EmbedIO/ExceptionHandler.cs
@@ -141,7 +141,7 @@ namespace EmbedIO
                 return;
             }
 
-            exception.Log(logSource, $"[{context.Id}] Unhandled exception.");
+            exception.Log(logSource, $"[{context.Id}] Unhandled exception: {exception.Message}");
 
             try
             {
@@ -169,7 +169,7 @@ namespace EmbedIO
             catch (Exception exception2)
 #pragma warning restore CA1031
             {
-                exception2.Log(logSource, $"[{context.Id}] Unhandled exception while handling exception.");
+                exception2.Log(logSource, $"[{context.Id}] Unhandled exception while handling exception: {exception2.Message}");
             }
         }
     }


### PR DESCRIPTION
This PR contains two small changes:
* Don't fix the `Swan.Lite` version to 3.1.0, but instead 3.* . Given that it is another unosqare library, this seems safe, and would mean that future releases of Swan.Lite can be picked up by Embedio users, without the need for an Embedio release.
* Improve some log statements to avoid swallowing useful messages. Because these log statements provide a message, the message of the exception is never seen. `ContextID Unhandled exception.` doesn't provide much information for a user to understand what has happened. Hopefully this makes debugging easier.

I realise that the contribution guide suggests discussing changes first - hopefully doing that on this PR is sufficient in this case.

PS: Thank you for this helpful, and easy to use library. 